### PR TITLE
feat: add shared uploader UI

### DIFF
--- a/web/app/ingest/page.tsx
+++ b/web/app/ingest/page.tsx
@@ -1,47 +1,10 @@
-'use client';
-
-import { useState } from 'react';
-import { AutoPairCard } from '@/components/AutoPairCard';
-import { ingestDocument } from '@/lib/api';
+import Uploader from "@/components/Uploader";
 
 export default function IngestPage() {
-  const [text, setText] = useState('');
-  const [title, setTitle] = useState('');
-  const [result, setResult] = useState<any>();
-  const [loading, setLoading] = useState(false);
-
-  const onSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-    setLoading(true);
-    try {
-      const res = await ingestDocument({ text, title });
-      setResult(res);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
-    <main className="p-6 space-y-4">
-      <h1 className="text-xl font-semibold">采集入库</h1>
-      <form onSubmit={onSubmit} className="space-y-3">
-        <input
-          className="border p-2 w-full"
-          placeholder="标题"
-          value={title}
-          onChange={event => setTitle(event.target.value)}
-        />
-        <textarea
-          className="border p-2 w-full h-48"
-          placeholder="粘贴文本或上传文件"
-          value={text}
-          onChange={event => setText(event.target.value)}
-        />
-        <button className="bg-blue-600 text-white px-4 py-2" disabled={loading} type="submit">
-          {loading ? '处理中…' : '入库'}
-        </button>
-      </form>
-      {result && <AutoPairCard data={result.auto} docId={result.doc_id} />}
+    <main className="p-8">
+      <h1 className="text-3xl font-semibold mb-4">采集入库</h1>
+      <Uploader />
     </main>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,24 +1,11 @@
-import Link from 'next/link';
+import Uploader from "@/components/Uploader";
 
-const links = [
-  { href: '/ingest', label: '采集入库' },
-  { href: '/compare/demo', label: '比对示例' },
-  { href: '/documents', label: '文档库' },
-  { href: '/batch', label: '批量处理' }
-];
-
-export default function HomePage() {
+export default function Home() {
   return (
-    <main className="p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">年报对照平台</h1>
-      <p>欢迎使用年度报告自动比对系统。</p>
-      <nav className="flex flex-col gap-2">
-        {links.map(link => (
-          <Link key={link.href} className="text-blue-600" href={link.href}>
-            {link.label}
-          </Link>
-        ))}
-      </nav>
+    <main className="p-8">
+      <h1 className="text-4xl font-bold mb-2">年报对照平台</h1>
+      <p className="text-gray-600 mb-6">欢迎使用年度报告自动比对系统。</p>
+      <Uploader />
     </main>
   );
 }

--- a/web/components/Uploader.tsx
+++ b/web/components/Uploader.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
+
+export default function Uploader() {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [url, setUrl] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [log, setLog] = useState<string[]>([]);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  function pushLog(s: string) {
+    setLog((prev) => [...prev, s]);
+  }
+
+  async function ingestViaFile(file: File) {
+    const fd = new FormData();
+    fd.append('file', file);
+    if (title) fd.append('title', title);
+    const r = await fetch(`${API_BASE}/ingest`, { method: 'POST', body: fd });
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  }
+
+  async function ingestViaUrl(u: string) {
+    const body = { url: u, ...(title ? { title } : {}) };
+    const r = await fetch(`${API_BASE}/ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  }
+
+  async function maybeCompare(auto: any, rightDocId: number) {
+    if (auto?.paired_with) {
+      pushLog(
+        `已自动匹配到上一年（doc_id=${auto.paired_with}，置信度=${auto.confidence ?? 'NA'}），开始比对…`
+      );
+      const r = await fetch(`${API_BASE}/compare`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ left_doc_id: auto.paired_with, right_doc_id: rightDocId }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      const data = await r.json();
+      const pid = data.id ?? data.pair_id ?? data.comparison_id;
+      if (pid) {
+        router.push(`/compare/${pid}`);
+      } else {
+        pushLog('比对已完成，但未返回 pair_id。请手动在“库管理”里查看。');
+      }
+    } else {
+      pushLog('未自动匹配到上一年，你可以在“库管理”里手动选择配对对象。');
+    }
+  }
+
+  async function onUploadFile() {
+    const f = fileRef.current?.files?.[0];
+    if (!f) return;
+    setBusy(true);
+    setLog([]);
+    try {
+      pushLog(`上传文件：${f.name}`);
+      const res = await ingestViaFile(f);
+      pushLog(`入库成功，doc_id=${res.doc_id}`);
+      await maybeCompare(res.auto, res.doc_id);
+    } catch (e: any) {
+      pushLog(`错误：${e.message || e.toString()}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onUploadUrl() {
+    if (!url.trim()) return;
+    setBusy(true);
+    setLog([]);
+    try {
+      pushLog(`抓取链接：${url}`);
+      const res = await ingestViaUrl(url.trim());
+      pushLog(`入库成功，doc_id=${res.doc_id}`);
+      await maybeCompare(res.auto, res.doc_id);
+    } catch (e: any) {
+      pushLog(`错误：${e.message || e.toString()}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto mt-8">
+      <div className="rounded-2xl border p-6 shadow-sm bg-white">
+        <h2 className="text-2xl font-semibold mb-4">上传/抓取 PDF</h2>
+
+        <div className="grid gap-3">
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="标题（可选）"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <div className="flex items-center gap-3 flex-wrap">
+            <input
+              ref={fileRef}
+              type="file"
+              accept="application/pdf"
+              className="border rounded px-3 py-2"
+            />
+            <button
+              disabled={busy}
+              onClick={onUploadFile}
+              className="px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+            >
+              选择 PDF 并上传
+            </button>
+          </div>
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <input
+              className="border rounded px-3 py-2 flex-1 min-w-[260px]"
+              placeholder="粘贴 PDF 链接（http/https）"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+            <button
+              disabled={busy || !url.trim()}
+              onClick={onUploadUrl}
+              className="px-4 py-2 rounded bg-indigo-600 text-white disabled:opacity-50"
+            >
+              通过链接上传
+            </button>
+          </div>
+
+          <p className="text-gray-500 text-sm">
+            提示：先上传上一年（如 2023），再上传当年（如 2024）。当年上传完成后系统会自动匹配上一年并发起比对。
+          </p>
+
+          <div className="mt-2">
+            <h3 className="font-medium mb-1">调试日志</h3>
+            <pre className="bg-gray-50 border rounded p-3 whitespace-pre-wrap min-h-[96px]">
+              {log.join('\n')}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,10 +1,13 @@
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
+
 export async function ingestDocument(payload: { text: string; title: string }) {
   const formData = new FormData();
   formData.append('text', payload.text);
   formData.append('title', payload.title);
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000'}/ingest`, {
+  const res = await fetch(`${API_BASE}/ingest`, {
     method: 'POST',
-    body: formData
+    body: formData,
   });
   if (!res.ok) {
     throw new Error('入库失败');
@@ -13,7 +16,7 @@ export async function ingestDocument(payload: { text: string; title: string }) {
 }
 
 export async function fetchDiff(leftId: number, rightId: number) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000'}/diff/${leftId}/${rightId}`);
+  const res = await fetch(`${API_BASE}/diff/${leftId}/${rightId}`);
   if (!res.ok) {
     throw new Error('获取比对结果失败');
   }


### PR DESCRIPTION
## Summary
- add a reusable uploader component supporting PDF files and links with auto-compare routing
- refresh the home page to present the uploader card
- reuse the uploader on the ingest page and expose a shared API_BASE helper

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d916e0102c83208477cdea32ba2388