### PR TITLE
feat: add dual year uploader workflow

### DIFF
--- a/web/app/ingest/page.tsx
+++ b/web/app/ingest/page.tsx
@@ -1,47 +1,10 @@
-'use client';
-
-import { useState } from 'react';
-import { AutoPairCard } from '@/components/AutoPairCard';
-import { ingestDocument } from '@/lib/api';
+import DualUploader from "@/components/DualUploader";
 
 export default function IngestPage() {
-  const [text, setText] = useState('');
-  const [title, setTitle] = useState('');
-  const [result, setResult] = useState<any>();
-  const [loading, setLoading] = useState(false);
-
-  const onSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-    setLoading(true);
-    try {
-      const res = await ingestDocument({ text, title });
-      setResult(res);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
-    <main className="p-6 space-y-4">
-      <h1 className="text-xl font-semibold">采集入库</h1>
-      <form onSubmit={onSubmit} className="space-y-3">
-        <input
-          className="border p-2 w-full"
-          placeholder="标题"
-          value={title}
-          onChange={event => setTitle(event.target.value)}
-        />
-        <textarea
-          className="border p-2 w-full h-48"
-          placeholder="粘贴文本或上传文件"
-          value={text}
-          onChange={event => setText(event.target.value)}
-        />
-        <button className="bg-blue-600 text-white px-4 py-2" disabled={loading} type="submit">
-          {loading ? '处理中…' : '入库'}
-        </button>
-      </form>
-      {result && <AutoPairCard data={result.auto} docId={result.doc_id} />}
+    <main className="p-8">
+      <h1 className="text-3xl font-semibold mb-4">采集入库</h1>
+      <DualUploader />
     </main>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,24 +1,11 @@
-import Link from 'next/link';
+import DualUploader from "@/components/DualUploader";
 
-const links = [
-  { href: '/ingest', label: '采集入库' },
-  { href: '/compare/demo', label: '比对示例' },
-  { href: '/documents', label: '文档库' },
-  { href: '/batch', label: '批量处理' }
-];
-
-export default function HomePage() {
+export default function Home() {
   return (
-    <main className="p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">年报对照平台</h1>
-      <p>欢迎使用年度报告自动比对系统。</p>
-      <nav className="flex flex-col gap-2">
-        {links.map(link => (
-          <Link key={link.href} className="text-blue-600" href={link.href}>
-            {link.label}
-          </Link>
-        ))}
-      </nav>
+    <main className="p-8">
+      <h1 className="text-4xl font-bold mb-2">年报对照平台</h1>
+      <p className="text-gray-600 mb-6">欢迎使用年度报告自动比对系统。</p>
+      <DualUploader />
     </main>
   );
 }

--- a/web/components/DualUploader.tsx
+++ b/web/components/DualUploader.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
+
+type Stat = 'idle'|'uploading'|'done'|'error';
+type UploadState = {
+  year: number;
+  fileKey: number;
+  filename?: string;
+  progress: number;
+  status: Stat;
+  docId?: number;
+  msg?: string;
+};
+
+function ProgressBar({ value }: { value: number }) {
+  return (
+    <div className="h-2 bg-gray-200 rounded w-full">
+      <div
+        className="h-2 bg-indigo-600 rounded"
+        style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+      />
+    </div>
+  );
+}
+
+export default function DualUploader() {
+  const now = new Date().getFullYear();
+  const router = useRouter();
+
+  const prevRef = useRef<HTMLInputElement | null>(null);
+  const currRef = useRef<HTMLInputElement | null>(null);
+
+  const [busy, setBusy] = useState(false);
+  const [prev, setPrev] = useState<UploadState>({
+    year: now - 1,
+    fileKey: 0,
+    progress: 0,
+    status: 'idle',
+  });
+  const [curr, setCurr] = useState<UploadState>({
+    year: now,
+    fileKey: 0,
+    progress: 0,
+    status: 'idle',
+  });
+
+  const canCompare =
+    prev.status === 'done' &&
+    curr.status === 'done' &&
+    !!prev.docId &&
+    !!curr.docId &&
+    !busy;
+
+  function resetInput(which: 'prev' | 'curr') {
+    if (which === 'prev' && prevRef.current) {
+      try {
+        prevRef.current.value = '';
+      } catch {}
+    }
+    if (which === 'curr' && currRef.current) {
+      try {
+        currRef.current.value = '';
+      } catch {}
+    }
+    if (which === 'prev') {
+      setPrev((s) => ({ ...s, fileKey: s.fileKey + 1 }));
+    } else {
+      setCurr((s) => ({ ...s, fileKey: s.fileKey + 1 }));
+    }
+  }
+
+  async function uploadFile(which: 'prev' | 'curr') {
+    const node = which === 'prev' ? prevRef.current : currRef.current;
+    const state = which === 'prev' ? prev : curr;
+    const setState = which === 'prev' ? setPrev : setCurr;
+    const f = node?.files?.[0];
+    if (!f) return;
+
+    setBusy(true);
+    setState((s) => ({
+      ...s,
+      status: 'uploading',
+      progress: 0,
+      filename: f.name,
+      msg: undefined,
+      docId: undefined,
+    }));
+
+    const fd = new FormData();
+    fd.append('file', f);
+    fd.append('year', String(state.year));
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', `${API_BASE}/ingest`, true);
+
+    xhr.upload.onprogress = (evt) => {
+      if (evt.lengthComputable) {
+        const p = Math.round((evt.loaded / evt.total) * 100);
+        setState((s) => ({ ...s, progress: p }));
+      }
+    };
+
+    xhr.onerror = () => {
+      setState((s) => ({ ...s, status: 'error', msg: '网络错误', docId: undefined }));
+      setBusy(false);
+      resetInput(which);
+    };
+
+    xhr.onload = () => {
+      try {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          const res = JSON.parse(xhr.responseText || '{}');
+          setState((s) => ({
+            ...s,
+            status: 'done',
+            progress: 100,
+            docId: res.doc_id,
+            msg: `doc_id=${res.doc_id}`,
+          }));
+        } else {
+          setState((s) => ({
+            ...s,
+            status: 'error',
+            msg: `${xhr.status} ${xhr.statusText}`,
+            docId: undefined,
+          }));
+        }
+      } catch (e: any) {
+        setState((s) => ({
+          ...s,
+          status: 'error',
+          msg: e?.message || '解析响应失败',
+          docId: undefined,
+        }));
+      } finally {
+        setBusy(false);
+        resetInput(which);
+      }
+    };
+
+    xhr.send(fd);
+  }
+
+  async function startCompare() {
+    if (!canCompare) return;
+    setBusy(true);
+    try {
+      const r = await fetch(`${API_BASE}/compare`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ left_doc_id: prev.docId, right_doc_id: curr.docId }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      const data = await r.json();
+      const pid = data.id ?? data.pair_id ?? data.comparison_id;
+      if (pid) {
+        router.push(`/compare/${pid}`);
+      } else {
+        alert('比对完成，但未返回 pair_id，请到库管理或最近任务查看。');
+      }
+    } catch (e: any) {
+      alert(`比对失败：${e?.message || e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function resetAll() {
+    if (prevRef.current) {
+      try {
+        prevRef.current.value = '';
+      } catch {}
+    }
+    if (currRef.current) {
+      try {
+        currRef.current.value = '';
+      } catch {}
+    }
+    setPrev((s) => ({
+      year: now - 1,
+      fileKey: s.fileKey + 1,
+      progress: 0,
+      status: 'idle',
+      filename: undefined,
+      docId: undefined,
+      msg: undefined,
+    }));
+    setCurr((s) => ({
+      year: now,
+      fileKey: s.fileKey + 1,
+      progress: 0,
+      status: 'idle',
+      filename: undefined,
+      docId: undefined,
+      msg: undefined,
+    }));
+    setBusy(false);
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto mt-6 space-y-6">
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="rounded-2xl border p-5 bg-white shadow-sm">
+          <h3 className="text-lg font-semibold mb-3">上传上一年度</h3>
+          <div className="flex items-center gap-3 mb-3">
+            <label className="text-sm text-gray-600">年份</label>
+            <input
+              type="number"
+              min={2000}
+              max={9999}
+              value={prev.year}
+              onChange={(e) =>
+                setPrev((s) => ({ ...s, year: Number(e.target.value || now - 1) }))
+              }
+              className="w-28 border rounded px-2 py-1"
+            />
+          </div>
+          <div className="flex items-center gap-3 flex-wrap">
+            <input
+              key={prev.fileKey}
+              ref={prevRef}
+              type="file"
+              accept="application/pdf"
+              className="border rounded px-3 py-2"
+              onClick={(e) => {
+                (e.currentTarget as HTMLInputElement).value = '';
+              }}
+            />
+            <button
+              onClick={() => uploadFile('prev')}
+              disabled={busy}
+              className="px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+            >
+              上传上一年 PDF
+            </button>
+          </div>
+          <div className="mt-3 space-y-1">
+            <ProgressBar value={prev.progress} />
+            <div className="text-sm text-gray-600">
+              {prev.status === 'idle' && '等待上传…'}
+              {prev.status === 'uploading' && `上传中：${prev.filename} (${prev.progress}%)`}
+              {prev.status === 'done' && `上传完成：${prev.filename}（doc_id=${prev.docId}）`}
+              {prev.status === 'error' && `上传失败：${prev.msg || ''}`}
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border p-5 bg-white shadow-sm">
+          <h3 className="text-lg font-semibold mb-3">上传本年度</h3>
+          <div className="flex items-center gap-3 mb-3">
+            <label className="text-sm text-gray-600">年份</label>
+            <input
+              type="number"
+              min={2000}
+              max={9999}
+              value={curr.year}
+              onChange={(e) =>
+                setCurr((s) => ({ ...s, year: Number(e.target.value || now) }))
+              }
+              className="w-28 border rounded px-2 py-1"
+            />
+          </div>
+          <div className="flex items-center gap-3 flex-wrap">
+            <input
+              key={curr.fileKey}
+              ref={currRef}
+              type="file"
+              accept="application/pdf"
+              className="border rounded px-3 py-2"
+              onClick={(e) => {
+                (e.currentTarget as HTMLInputElement).value = '';
+              }}
+            />
+            <button
+              onClick={() => uploadFile('curr')}
+              disabled={busy}
+              className="px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+            >
+              上传本年 PDF
+            </button>
+          </div>
+          <div className="mt-3 space-y-1">
+            <ProgressBar value={curr.progress} />
+            <div className="text-sm text-gray-600">
+              {curr.status === 'idle' && '等待上传…'}
+              {curr.status === 'uploading' && `上传中：${curr.filename} (${curr.progress}%)`}
+              {curr.status === 'done' && `上传完成：${curr.filename}（doc_id=${curr.docId}）`}
+              {curr.status === 'error' && `上传失败：${curr.msg || ''}`}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={startCompare}
+          disabled={!canCompare}
+          className="px-4 py-2 rounded bg-indigo-600 text-white disabled:opacity-50"
+        >
+          开始比对
+        </button>
+        <button onClick={resetAll} className="px-4 py-2 rounded border">
+          重置
+        </button>
+        <span className="text-sm text-gray-600">
+          需先完成两份上传后才可点击“开始比对”。默认以“上一年”为 left，“本年”为 right。
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web/components/Uploader.tsx
+++ b/web/components/Uploader.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
+
+export default function Uploader() {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [url, setUrl] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [log, setLog] = useState<string[]>([]);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const [fileKey, setFileKey] = useState(0);
+
+  function pushLog(s: string) {
+    setLog((prev) => [...prev, s]);
+  }
+
+  async function ingestViaFile(file: File) {
+    const fd = new FormData();
+    fd.append('file', file);
+    if (title) fd.append('title', title);
+    const r = await fetch(`${API_BASE}/ingest`, { method: 'POST', body: fd });
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  }
+
+  async function ingestViaUrl(u: string) {
+    const body = { url: u, ...(title ? { title } : {}) };
+    const r = await fetch(`${API_BASE}/ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  }
+
+  async function maybeCompare(auto: any, rightDocId: number) {
+    if (auto?.paired_with) {
+      pushLog(
+        `已自动匹配到上一年（doc_id=${auto.paired_with}，置信度=${auto.confidence ?? 'NA'}），开始比对…`
+      );
+      const r = await fetch(`${API_BASE}/compare`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ left_doc_id: auto.paired_with, right_doc_id: rightDocId }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      const data = await r.json();
+      const pid = data.id ?? data.pair_id ?? data.comparison_id;
+      if (pid) {
+        router.push(`/compare/${pid}`);
+      } else {
+        pushLog('比对已完成，但未返回 pair_id。请手动在“库管理”里查看。');
+      }
+    } else {
+      pushLog('未自动匹配到上一年，你可以在“库管理”里手动选择配对对象。');
+    }
+  }
+
+  function resetInputs() {
+    try {
+      if (fileRef.current) fileRef.current.value = '';
+    } catch {}
+    setFileKey((k) => k + 1);
+    // 如需清空标题或链接，可在此启用：
+    // setTitle('');
+    // setUrl('');
+  }
+
+  async function onUploadFile() {
+    const f = fileRef.current?.files?.[0];
+    if (!f) return;
+    setBusy(true);
+    setLog([]);
+    try {
+      pushLog(`上传文件：${f.name}`);
+      const res = await ingestViaFile(f);
+      pushLog(`入库成功，doc_id=${res.doc_id}`);
+      await maybeCompare(res.auto, res.doc_id);
+    } catch (e: any) {
+      pushLog(`错误：${e.message || e.toString()}`);
+    } finally {
+      setBusy(false);
+      resetInputs();
+    }
+  }
+
+  async function onUploadUrl() {
+    if (!url.trim()) return;
+    setBusy(true);
+    setLog([]);
+    try {
+      pushLog(`抓取链接：${url}`);
+      const res = await ingestViaUrl(url.trim());
+      pushLog(`入库成功，doc_id=${res.doc_id}`);
+      await maybeCompare(res.auto, res.doc_id);
+    } catch (e: any) {
+      pushLog(`错误：${e.message || e.toString()}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto mt-8">
+      <div className="rounded-2xl border p-6 shadow-sm bg-white">
+        <h2 className="text-2xl font-semibold mb-4">上传/抓取 PDF</h2>
+
+        <div className="grid gap-3">
+          <input
+            className="border rounded px-3 py-2"
+            placeholder="标题（可选）"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <div className="flex items-center gap-3 flex-wrap">
+            <input
+              key={fileKey}
+              ref={fileRef}
+              type="file"
+              accept="application/pdf"
+              className="border rounded px-3 py-2"
+              onClick={(e) => {
+                (e.currentTarget as HTMLInputElement).value = '';
+              }}
+            />
+            <button
+              disabled={busy}
+              onClick={onUploadFile}
+              className="px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+            >
+              选择 PDF 并上传
+            </button>
+          </div>
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <input
+              className="border rounded px-3 py-2 flex-1 min-w-[260px]"
+              placeholder="粘贴 PDF 链接（http/https）"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+            <button
+              disabled={busy || !url.trim()}
+              onClick={onUploadUrl}
+              className="px-4 py-2 rounded bg-indigo-600 text-white disabled:opacity-50"
+            >
+              通过链接上传
+            </button>
+          </div>
+
+          <p className="text-gray-500 text-sm">
+            提示：先上传上一年（如 2023），再上传当年（如 2024）。当年上传完成后系统会自动匹配上一年并发起比对。
+          </p>
+
+          <div className="mt-2">
+            <h3 className="font-medium mb-1">调试日志</h3>
+            <pre className="bg-gray-50 border rounded p-3 whitespace-pre-wrap min-h-[96px]">
+              {log.join('\n')}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,10 +1,13 @@
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
+
 export async function ingestDocument(payload: { text: string; title: string }) {
   const formData = new FormData();
   formData.append('text', payload.text);
   formData.append('title', payload.title);
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000'}/ingest`, {
+  const res = await fetch(`${API_BASE}/ingest`, {
     method: 'POST',
-    body: formData
+    body: formData,
   });
   if (!res.ok) {
     throw new Error('入库失败');
@@ -13,7 +16,7 @@ export async function ingestDocument(payload: { text: string; title: string }) {
 }
 
 export async function fetchDiff(leftId: number, rightId: number) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000'}/diff/${leftId}/${rightId}`);
+  const res = await fetch(`${API_BASE}/diff/${leftId}/${rightId}`);
   if (!res.ok) {
     throw new Error('获取比对结果失败');
   }


### PR DESCRIPTION
## Summary
- add a dual uploader component that guides previous and current year uploads with progress indicators, status messaging, and a Start Compare CTA
- update the home and ingest pages to share the new dual uploader experience

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d916e0102c83208477cdea32ba2388